### PR TITLE
feat: PUT /worker/:id — update worker profiles

### DIFF
--- a/backend/src/routes/worker.js
+++ b/backend/src/routes/worker.js
@@ -115,6 +115,46 @@ router.get('/:id/payments', (req, res) => {
 });
 
 /**
+ * PUT /worker/:id
+ * Update a worker's profile (name, phone, photo_url, role, lightning_address).
+ */
+router.put('/:id', (req, res) => {
+  const db = getDb();
+  const worker = db.prepare('SELECT * FROM workers WHERE id = ?').get(req.params.id);
+  if (!worker) return res.status(404).json({ error: 'Worker not found' });
+
+  const allowed = ['name', 'phone', 'photo_url', 'role', 'lightning_address'];
+  const updates = [];
+  const values = [];
+
+  for (const field of allowed) {
+    if (req.body[field] !== undefined) {
+      if (field === 'role') {
+        const validRoles = ['worker', 'foreman'];
+        if (!validRoles.includes(req.body[field])) {
+          return res.status(400).json({ error: `Invalid role. Must be one of: ${validRoles.join(', ')}` });
+        }
+      }
+      if (field === 'name' && !req.body[field]) {
+        return res.status(400).json({ error: 'name cannot be empty' });
+      }
+      updates.push(`${field} = ?`);
+      values.push(req.body[field]);
+    }
+  }
+
+  if (updates.length === 0) {
+    return res.status(400).json({ error: 'No valid fields to update' });
+  }
+
+  values.push(req.params.id);
+  db.prepare(`UPDATE workers SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+
+  const updated = db.prepare('SELECT * FROM workers WHERE id = ?').get(req.params.id);
+  res.json(updated);
+});
+
+/**
  * GET /worker
  * List workers (optionally filtered by farm_id).
  */

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -64,6 +64,7 @@ function request(method, urlPath, body) {
 
 const get = (p) => request('GET', p);
 const post = (p, b) => request('POST', p, b);
+const put = (p, b) => request('PUT', p, b);
 
 // ------------------------------------------------------------------ lifecycle
 
@@ -183,6 +184,55 @@ describe('Worker', () => {
     assert.equal(res.status, 200);
     assert.ok(Array.isArray(res.body.payments));
     assert.equal(res.body.payments.length, 0);
+  });
+});
+
+describe('Worker update (PUT /worker/:id)', () => {
+  test('PUT /worker/:id updates name and phone', async () => {
+    const res = await put(`/worker/${workerId}`, {
+      name: 'Updated Worker',
+      phone: '+503-1111-2222',
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.name, 'Updated Worker');
+    assert.equal(res.body.phone, '+503-1111-2222');
+    assert.equal(res.body.id, workerId);
+  });
+
+  test('PUT /worker/:id updates photo_url', async () => {
+    const res = await put(`/worker/${workerId}`, {
+      photo_url: 'https://example.com/photo.jpg',
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.photo_url, 'https://example.com/photo.jpg');
+  });
+
+  test('PUT /worker/:id updates role', async () => {
+    const res = await put(`/worker/${workerId}`, { role: 'foreman' });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.role, 'foreman');
+    // Restore original role
+    await put(`/worker/${workerId}`, { role: 'worker' });
+  });
+
+  test('PUT /worker/:id returns 400 for invalid role', async () => {
+    const res = await put(`/worker/${workerId}`, { role: 'ceo' });
+    assert.equal(res.status, 400);
+  });
+
+  test('PUT /worker/:id returns 400 for empty name', async () => {
+    const res = await put(`/worker/${workerId}`, { name: '' });
+    assert.equal(res.status, 400);
+  });
+
+  test('PUT /worker/:id returns 400 with no valid fields', async () => {
+    const res = await put(`/worker/${workerId}`, { favorite_color: 'blue' });
+    assert.equal(res.status, 400);
+  });
+
+  test('PUT /worker/:id returns 404 for unknown worker', async () => {
+    const res = await put('/worker/nonexistent-id', { name: 'Ghost' });
+    assert.equal(res.status, 404);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `PUT /worker/:id` endpoint to update name, phone, photo_url, role, and lightning_address
- Validates role against `['worker', 'foreman']`, rejects empty names, returns 400 on no valid fields
- 7 new integration tests (46 total, all passing)

Closes #7

## Test plan
- [x] `PUT /worker/:id` updates name and phone
- [x] `PUT /worker/:id` updates photo_url
- [x] `PUT /worker/:id` updates role (with restore)
- [x] Returns 400 for invalid role, empty name, no valid fields
- [x] Returns 404 for unknown worker
- [x] All 46 tests pass

```
curl -X PUT http://134.122.8.237:3002/worker/<id> \
  -H "Content-Type: application/json" \
  -d '{"name": "María", "phone": "+503-7777-8888"}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)