### PR TITLE
feat: payroll CSV export endpoint

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,7 @@
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       }
     },
     "node_modules/accepts": {

--- a/backend/src/routes/farm.js
+++ b/backend/src/routes/farm.js
@@ -54,4 +54,52 @@ router.get('/:id', (req, res) => {
   res.json({ ...farm, worker_count: workerCount });
 });
 
+/**
+ * GET /farm/:id/export
+ * Export payroll CSV for a farm.
+ * Query params:
+ *   from — optional start date (YYYY-MM-DD)
+ *   to   — optional end date (YYYY-MM-DD)
+ */
+router.get('/:id/export', (req, res) => {
+  const db = getDb();
+  const farm = db.prepare('SELECT * FROM farms WHERE id = ?').get(req.params.id);
+  if (!farm) return res.status(404).json({ error: 'Farm not found' });
+
+  const { from, to } = req.query;
+
+  let sql = `
+    SELECT w.name AS worker_name, s.date AS shift_date,
+           p.amount_sats, p.status, p.paid_at
+    FROM payments p
+    JOIN workers w ON w.id = p.worker_id
+    JOIN shifts s ON s.id = p.shift_id
+    WHERE s.farm_id = ?
+  `;
+  const params = [req.params.id];
+
+  if (from) {
+    sql += ' AND s.date >= ?';
+    params.push(from);
+  }
+  if (to) {
+    sql += ' AND s.date <= ?';
+    params.push(to);
+  }
+
+  sql += ' ORDER BY s.date, w.name';
+
+  const rows = db.prepare(sql).all(...params);
+
+  const header = 'worker_name,shift_date,amount_sats,status,paid_at';
+  const csvRows = rows.map(r =>
+    [r.worker_name, r.shift_date, r.amount_sats, r.status, r.paid_at].join(',')
+  );
+  const csv = [header, ...csvRows].join('\n');
+
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader('Content-Disposition', `attachment; filename="${farm.name}-payroll.csv"`);
+  res.send(csv);
+});
+
 module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -121,6 +121,7 @@ if (require.main === module) {
     console.log('    POST   /lot/:id/transfer');
     console.log('    GET    /lot/:id/provenance');
     console.log('    POST   /payroll');
+    console.log('    GET    /farm/:id/export');
     console.log('    GET    /worker/:id/payments');
     console.log('    GET    /worker/:id/today');
     console.log('    GET    /provenance/:lotId');

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -389,6 +389,58 @@ describe('BTC Price', () => {
   });
 });
 
+// ------------------------------------------------------------------ Feature: Payroll CSV export
+
+describe('Payroll CSV export', () => {
+  test('GET /farm/:id/export returns CSV with header', async () => {
+    const res = await get(`/farm/${farmId}/export`);
+    assert.equal(res.status, 200);
+    const lines = res.body.split('\n');
+    assert.equal(lines[0], 'worker_name,shift_date,amount_sats,status,paid_at');
+    // Payroll was processed in earlier tests — should have at least one data row
+    assert.ok(lines.length >= 2, 'should have header + at least 1 data row');
+  });
+
+  test('GET /farm/:id/export includes correct payment data', async () => {
+    const res = await get(`/farm/${farmId}/export`);
+    const lines = res.body.split('\n');
+    const dataLines = lines.slice(1).filter(l => l.length > 0);
+    // Each row should have 5 comma-separated fields
+    for (const line of dataLines) {
+      const fields = line.split(',');
+      assert.equal(fields.length, 5, `expected 5 fields, got: ${line}`);
+      assert.ok(Number(fields[2]) > 0, 'amount_sats should be positive');
+    }
+  });
+
+  test('GET /farm/:id/export with date filter returns filtered results', async () => {
+    // Use a far-future date range that won't match any shifts
+    const res = await get(`/farm/${farmId}/export?from=2099-01-01&to=2099-12-31`);
+    assert.equal(res.status, 200);
+    const lines = res.body.split('\n').filter(l => l.length > 0);
+    // Should only have the header row — no data matches the future date
+    assert.equal(lines.length, 1, 'no data rows for far-future date filter');
+  });
+
+  test('GET /farm/:id/export returns 404 for unknown farm', async () => {
+    const res = await get('/farm/nonexistent-farm-id/export');
+    assert.equal(res.status, 404);
+  });
+
+  test('GET /farm/:id/export returns empty CSV for farm with no payments', async () => {
+    // Create a fresh farm with no shifts/payments
+    const farmRes = await post('/farm', {
+      name: 'Empty Farm', location: 'Nowhere', altitude_m: 100, owner_name: 'Nobody'
+    });
+    assert.equal(farmRes.status, 201);
+    const res = await get(`/farm/${farmRes.body.id}/export`);
+    assert.equal(res.status, 200);
+    const lines = res.body.split('\n').filter(l => l.length > 0);
+    assert.equal(lines.length, 1, 'only header row for farm with no payments');
+    assert.equal(lines[0], 'worker_name,shift_date,amount_sats,status,paid_at');
+  });
+});
+
 // ------------------------------------------------------------------ Feature 2: Worker today status
 
 describe('Worker today status', () => {


### PR DESCRIPTION
## Summary
- Adds `GET /farm/:id/export` endpoint returning payroll data as CSV
- Supports optional `from` and `to` query params for date filtering
- Returns worker_name, shift_date, amount_sats, status, paid_at — required for labor compliance
- 5 new integration tests (44 total passing)

Closes #11

## Test plan
- [x] All 44 tests pass (`node --test test/api.test.js`)
- [x] CSV header correct
- [x] Payment data rows have 5 fields
- [x] Date filtering excludes out-of-range shifts
- [x] 404 for unknown farm
- [x] Empty CSV (header only) for farm with no payments

🤖 Generated with [Claude Code](https://claude.com/claude-code)