### PR TITLE
feat: session auto-cleanup cron

### DIFF
--- a/backend/src/lib/cleanup.js
+++ b/backend/src/lib/cleanup.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { getDb } = require('../db');
+
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const MAX_AGE_HOURS = 24;
+
+/**
+ * Delete closed shifts (and their checkins) older than MAX_AGE_HOURS.
+ * Returns the number of shifts removed.
+ */
+function cleanupOldShifts() {
+  const db = getDb();
+  const cutoff = new Date(Date.now() - MAX_AGE_HOURS * 3600000).toISOString();
+
+  const oldShifts = db.prepare(`
+    SELECT id FROM shifts
+    WHERE status = 'closed' AND closed_at < ?
+  `).all(cutoff);
+
+  if (oldShifts.length === 0) return 0;
+
+  const ids = oldShifts.map(s => s.id);
+
+  const deleteCheckins = db.prepare('DELETE FROM checkins WHERE shift_id = ?');
+  const deletePayments = db.prepare('DELETE FROM payments WHERE shift_id = ?');
+  const deleteShift = db.prepare('DELETE FROM shifts WHERE id = ?');
+
+  const cleanup = db.transaction((shiftIds) => {
+    for (const id of shiftIds) {
+      deleteCheckins.run(id);
+      deletePayments.run(id);
+      deleteShift.run(id);
+    }
+  });
+
+  cleanup(ids);
+  console.log(`[cleanup] Removed ${ids.length} closed shift(s) older than ${MAX_AGE_HOURS}h`);
+  return ids.length;
+}
+
+/**
+ * Start the periodic cleanup timer. Returns the interval handle.
+ */
+function startCleanupCron() {
+  // Run once on startup
+  cleanupOldShifts();
+  return setInterval(cleanupOldShifts, CLEANUP_INTERVAL_MS);
+}
+
+module.exports = { cleanupOldShifts, startCleanupCron, CLEANUP_INTERVAL_MS, MAX_AGE_HOURS };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -15,6 +15,8 @@ const payrollRoutes = require('./routes/payroll');
 const provenanceRoutes = require('./routes/provenance');
 const priceRoutes = require('./routes/price');
 
+const { startCleanupCron } = require('./lib/cleanup');
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -106,6 +108,7 @@ app.use((err, req, res, next) => {
 
 // ------------------------------------------------------------------ start
 if (require.main === module) {
+  startCleanupCron();
   app.listen(PORT, () => {
     console.log('');
     console.log('  Chainbytes Coffee Supply Chain — Backend API');

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -463,3 +463,77 @@ describe('Worker auto-registration on check-in', () => {
     assert.equal(res.body.name, 'Worker abcdef');
   });
 });
+
+// ------------------------------------------------------------------ cleanup
+
+describe('Session auto-cleanup', () => {
+  const { cleanupOldShifts } = require('../src/lib/cleanup');
+  const { getDb } = require('../src/db');
+  const { v4: uuidv4 } = require('uuid');
+
+  test('cleanupOldShifts removes closed shifts older than 24h', () => {
+    const db = getDb();
+    const oldId = uuidv4();
+    const oldDate = new Date(Date.now() - 48 * 3600000).toISOString(); // 48h ago
+
+    // Insert a closed shift with old closed_at
+    db.prepare(`
+      INSERT INTO shifts (id, farm_id, foreman_id, date, status, closed_at)
+      VALUES (?, ?, ?, '2026-01-01', 'closed', ?)
+    `).run(oldId, farmId, foremanId, oldDate);
+
+    // Insert a checkin for this shift
+    const checkinId = uuidv4();
+    db.prepare(`
+      INSERT INTO checkins (id, shift_id, worker_id)
+      VALUES (?, ?, ?)
+    `).run(checkinId, oldId, workerId);
+
+    const removed = cleanupOldShifts();
+    assert.ok(removed >= 1, `Expected at least 1 removed, got ${removed}`);
+
+    // Verify shift and checkin are gone
+    const shift = db.prepare('SELECT id FROM shifts WHERE id = ?').get(oldId);
+    assert.equal(shift, undefined);
+    const checkin = db.prepare('SELECT id FROM checkins WHERE id = ?').get(checkinId);
+    assert.equal(checkin, undefined);
+  });
+
+  test('cleanupOldShifts does NOT remove recent closed shifts', () => {
+    const db = getDb();
+    const recentId = uuidv4();
+    const recentDate = new Date(Date.now() - 1 * 3600000).toISOString(); // 1h ago
+
+    db.prepare(`
+      INSERT INTO shifts (id, farm_id, foreman_id, date, status, closed_at)
+      VALUES (?, ?, ?, '2026-01-02', 'closed', ?)
+    `).run(recentId, farmId, foremanId, recentDate);
+
+    cleanupOldShifts();
+
+    const shift = db.prepare('SELECT id FROM shifts WHERE id = ?').get(recentId);
+    assert.ok(shift, 'Recent closed shift should NOT be removed');
+
+    // Cleanup for test isolation
+    db.prepare('DELETE FROM shifts WHERE id = ?').run(recentId);
+  });
+
+  test('cleanupOldShifts does NOT remove open shifts', () => {
+    const db = getDb();
+    const openId = uuidv4();
+    const oldDate = new Date(Date.now() - 48 * 3600000).toISOString();
+
+    db.prepare(`
+      INSERT INTO shifts (id, farm_id, foreman_id, date, status, closed_at)
+      VALUES (?, ?, ?, '2026-01-03', 'open', ?)
+    `).run(openId, farmId, foremanId, oldDate);
+
+    cleanupOldShifts();
+
+    const shift = db.prepare('SELECT id FROM shifts WHERE id = ?').get(openId);
+    assert.ok(shift, 'Open shifts should NOT be removed regardless of age');
+
+    // Cleanup
+    db.prepare('DELETE FROM shifts WHERE id = ?').run(openId);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `backend/src/lib/cleanup.js` — hourly cron that deletes closed shifts (+ checkins + payments) older than 24h
- Wired into server startup via `startCleanupCron()`
- Matches the old app's session cleanup behavior for labor compliance

## Tests
- 3 new tests (42 total, all passing):
  - Removes old closed shifts and their checkins
  - Preserves recently closed shifts
  - Preserves open shifts regardless of age

## Closes
Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)